### PR TITLE
modify MonthlyEnergyLogsFinder.averages to add params city_id

### DIFF
--- a/challenge3/webapp/yukaina/app/finders/monthly_energy_logs_finder.rb
+++ b/challenge3/webapp/yukaina/app/finders/monthly_energy_logs_finder.rb
@@ -1,14 +1,21 @@
 class MonthlyEnergyLogsFinder
-  def self.averages
-    MonthlyEnergyLog.
-      group_by_monthly_label.
-      select(
-        :monthly_label_id,
-        "AVG(temperature) AS avarage_temperature",
-        "AVG(daylight) AS avarage_daylight",
-        "AVG(production_volume) AS avarage_production_volume",
-      ).
-      includes(:monthly_label)
+  def self.averages(city_id: nil)
+    monthly_energy_log = MonthlyEnergyLog.
+                           group_by_monthly_label.
+                           select(
+                             :monthly_label_id,
+                             "AVG(temperature) AS avarage_temperature",
+                             "AVG(daylight) AS avarage_daylight",
+                             "AVG(production_volume) AS avarage_production_volume",
+                           ).
+                           includes(:monthly_label).
+                           order(:monthly_label_id)
+    return monthly_energy_log unless city_id
+
+    # city ごとに絞る場合は、houses を結合して条件と追加
+    monthly_energy_log.
+      joins(:house).
+      where(houses: { city_id: city_id })
   end
 
   def self.by_city

--- a/challenge3/webapp/yukaina/spec/finders/monthly_energy_logs_finder_spec.rb
+++ b/challenge3/webapp/yukaina/spec/finders/monthly_energy_logs_finder_spec.rb
@@ -51,14 +51,27 @@ RSpec.describe MonthlyEnergyLogsFinder do
   # rubocop:enable Naming/VariableNumber
 
   describe "averages" do
-    it "temperature, daylight, temperature の平均が出力されること" do
-      logs = MonthlyEnergyLogsFinder.averages
-      expect(logs.first["avarage_temperature"].floor(2).to_f).to eq 10.1
-      expect(logs.first["avarage_daylight"].floor(2).to_f).to eq 20.1
-      expect(logs.first["avarage_production_volume"]).to eq 101
-      expect(logs.second["avarage_temperature"].floor(2).to_f).to eq 20.2
-      expect(logs.second["avarage_daylight"].floor(2).to_f).to eq 30.2
-      expect(logs.second["avarage_production_volume"]).to eq 112
+    context "city_id の指定が無い場合" do
+      it "temperature, daylight, temperature の平均が出力されること" do
+        logs = MonthlyEnergyLogsFinder.averages
+        expect(logs.first["avarage_temperature"].floor(2).to_f).to eq 10.1
+        expect(logs.first["avarage_daylight"].floor(2).to_f).to eq 20.1
+        expect(logs.first["avarage_production_volume"]).to eq 101
+        expect(logs.second["avarage_temperature"].floor(2).to_f).to eq 20.2
+        expect(logs.second["avarage_daylight"].floor(2).to_f).to eq 30.2
+        expect(logs.second["avarage_production_volume"]).to eq 112
+      end
+    end
+
+    context "city_id がある場合" do
+      let(:tokyo_city) { City.find_by(name: "Tokyo") }
+
+      it do
+        logs = MonthlyEnergyLogsFinder.averages(city_id: tokyo_city.id)
+        expect(logs.first["avarage_temperature"].floor(2).to_f).to eq 10.0
+        expect(logs.first["avarage_daylight"].floor(2).to_f).to eq 20.0
+        expect(logs.first["avarage_production_volume"]).to eq 100
+      end
     end
   end
 


### PR DESCRIPTION
1. MonthlyEnergyLogsFinder.averages を city 単位で絞れるようにする
2. MonthlyEnergyLogsFinder.averages を年月の範囲で絞れるようにする
2. MonthlyEnergyLogsFinder.by_city を年月の範囲で絞れるようにする
3. JS をerb から切り離す
4. MonthlyEnergyLogs に city_id 列を追加する
5. cityの統廃合テーブル
  統合後は、cities に新規レコードを追加
  統廃合テーブルに廃止年月日、統合先のcity_id を持たせる
6. MonthlyEnergyLogsFinder.by_city のメソッド名変更
7. CircleCI